### PR TITLE
Replace console-based file search with Dir.glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/*
 .bundle
 USAGE.md
 spec/vcr/*
+.idea/*

--- a/lib/wordnik/configuration.rb
+++ b/lib/wordnik/configuration.rb
@@ -44,11 +44,11 @@ module Wordnik
       @user_agent = "ruby-#{Wordnik::VERSION}"
       # Build the default set of resource names from the filenames of the API documentation
       begin
-        api_docs_path = File.join(File.dirname(__FILE__), "../../api_docs")
-        @resource_names = `find #{api_docs_path} -name '*.json'`.split("\n").map {|f| f.split("/").last.sub('.json', '') }.sort
+        api_docs_path = File.join(File.dirname(__FILE__), '../../api_docs')
+        @resource_names = Dir.glob(File.join(api_docs_path, '*.json')).map {|f| f.split('/').last.sub('.json', '') }.sort
         true
       rescue
-        raise "Problem loading the resource files in ./api_docs/"
+        raise 'Problem loading the resource files in ./api_docs/'
       end
     end
 


### PR DESCRIPTION
On windows box console-based file search returned `File not found: '*.json'` and no API methods were created for `Wordnik` module.
